### PR TITLE
Added warn support for chaos-related modifiers

### DIFF
--- a/ExpeditionIcons.cs
+++ b/ExpeditionIcons.cs
@@ -592,6 +592,8 @@ public class ExpeditionIcons : BaseSettingsPlugin<ExpeditionIconsSettings>
                Settings.WarnReducedDamageTaken && mods.Any(x => x.Contains("ExpeditionRelicModifierReducedDamageTaken")) ||
                Settings.WarnBleed && mods.Any(x => x.Contains("ExpeditionRelicModifierBleedOnHitBleedDuration")) ||
                Settings.WarnCorrupted && mods.Any(x => x.Contains("ExpeditionRelicModifierExpeditionCorruptedItemsElite")) ||
+               Settings.WarnPoison && mods.Any(x => x.Contains("ExpeditionRelicModifierAllDamagePoisonsPoisonDuration")) ||
+               Settings.WarnPhysicalAsExtraChaos && mods.Any(x => x.Contains("ExpeditionRelicModifierDamageAddedAsChaos")) ||
                false;
     }
 

--- a/ExpeditionIconsSettings.cs
+++ b/ExpeditionIconsSettings.cs
@@ -155,6 +155,11 @@ public class ExpeditionIconsSettings : ISettings
 
     [Menu("Warn for bleed", parentIndex = 101)]
     public ToggleNode WarnBleed { get; set; } = new ToggleNode(false);
+    
+    [Menu("Warn for poison", parentIndex = 101)]
+    public ToggleNode WarnPoison { get; set; } = new ToggleNode(false);
+    [Menu("Warn for phys as chaos", parentIndex = 101)]
+    public ToggleNode WarnPhysicalAsExtraChaos { get; set; } = new ToggleNode(false);
 
     [Menu("Chest settings", index = 103, CollapsedByDefault = true)]
     [JsonIgnore]


### PR DESCRIPTION
- Added the ability for the planner to avoid `poison` and/or `physical as extra chaos` mods